### PR TITLE
Avoid crash when Server header is None

### DIFF
--- a/boom/_boom.py
+++ b/boom/_boom.py
@@ -74,7 +74,7 @@ def print_stats(total):
 
 def print_server_info(url, method):
     res = requests.head(url)
-    print 'Server Software: ' + res.headers['server']
+    print 'Server Software: %(server)s' % res.headers
     print 'Running %s %s' % (method, url)
 
 


### PR DESCRIPTION
On some tests, possibly triggered by #7, boom would crash in `print_server_info` because it used string concatenation, which fails when the value is `None`. This commit avoids the crash but doesn't fix the underlying missing header value.

```
Traceback (most recent call last):
  File "/Users/cadams/Library/Python/2.7/bin/boom", line 8, in <module>
    load_entry_point('boom==0.3', 'console_scripts', 'boom')()
  File "/Users/cadams/Library/Python/2.7/lib/python/site-packages/boom/_boom.py", line 207, in main
    args.method, args.data, args.content_type, args.auth)
  File "/Users/cadams/Library/Python/2.7/lib/python/site-packages/boom/_boom.py", line 136, in load
    print_server_info(url, method)
  File "/Users/cadams/Library/Python/2.7/lib/python/site-packages/boom/_boom.py", line 77, in print_server_info
    print 'Server Software: ' + res.headers['server']
TypeError: cannot concatenate 'str' and 'NoneType' objects
```
