### PR TITLE
Add support for SSL boom'ing

### DIFF
--- a/boom/_boom.py
+++ b/boom/_boom.py
@@ -167,8 +167,13 @@ def run(url, num=1, duration=None, method='GET', data=None, ct='text/plain',
 def resolve(url):
     parts = urlparse.urlparse(url)
     netloc = parts.netloc.rsplit(':')
+
     if len(netloc) == 1:
-        netloc.append('80')
+        if parts.scheme == 'https':
+            netloc.append('443')
+        else:
+            netloc.append('80')
+
     original = netloc[0]
     resolved = gethostbyname(original)
 

--- a/boom/tests.py
+++ b/boom/tests.py
@@ -111,5 +111,19 @@ class TestBoom(unittest.TestCase):
         self.assertEqual(original, 'localhost')
         self.assertEqual(resolved, 'localhost')
 
+    def test_resolve_no_scheme(self):
+        test_url = 'http://localhost'
+        url, original, resolved = resolve(test_url)
+        self.assertEqual(url, 'http://127.0.0.1:80')
+        self.assertEqual(original, 'localhost')
+        self.assertEqual(resolved, '127.0.0.1')
+
+    def test_resolve_no_scheme_ssl(self):
+        test_url = 'https://localhost'
+        url, original, resolved = resolve(test_url)
+        self.assertEqual(url, 'https://localhost:443')
+        self.assertEqual(original, 'localhost')
+        self.assertEqual(resolved, 'localhost')
+
 if __name__ == '__main__':
     run()


### PR DESCRIPTION
This just checks the URL scheme for SSL and if that exists, simply
leaves the hostname intact so it doesn't break the certificate checking.

I've also added unit tests for the resolve function. This seems to
work from my testing. Not quite sure what the motiviation to resolve
hostnames was in the first place was, so I may be breaking something.
