### PR TITLE
Added --validator option for validating request response data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,34 +72,44 @@ Boom! has more options::
     $ boom --help
     usage: boom [-h] [--version] [-m {GET,POST,DELETE,PUT,HEAD,OPTIONS}]
                 [--content-type CONTENT_TYPE] [-D DATA] [-c CONCURRENCY] [-a AUTH]
-                [--header HEADER] [--hook HOOK]  [--json-output]
-                [-n REQUESTS | -d DURATION]
+                [--header HEADER] [--pre-hook PRE_HOOK] [--post-hook POST_HOOK]
+                [--json-output] [-n REQUESTS | -d DURATION]
                 [url]
 
     Simple HTTP Load runner.
 
     positional arguments:
-    url                   URL to hit
+      url                   URL to hit
 
     optional arguments:
-    -h, --help            show this help message and exit
-    --version             Displays version and exits.
-    -m {GET,POST,DELETE,PUT,HEAD,OPTIONS}, --method {GET,POST,DELETE,PUT,HEAD,OPTIONS}
+      -h, --help            show this help message and exit
+      --version             Displays version and exits.
+      -m {GET,POST,DELETE,PUT,HEAD,OPTIONS}, --method {GET,POST,DELETE,PUT,HEAD,OPTIONS}
                             HTTP Method
-    --content-type CONTENT_TYPE
+      --content-type CONTENT_TYPE
                             Content-Type
-    -D DATA, --data DATA  Data. Prefixed by "py:" to point a python callable.
-    -c CONCURRENCY, --concurrency CONCURRENCY
+      -D DATA, --data DATA  Data. Prefixed by "py:" to point a python callable.
+      -c CONCURRENCY, --concurrency CONCURRENCY
                             Concurrency
-    -a AUTH, --auth AUTH  Basic authentication user:password
-    --header HEADER       Custom header. name:value
-    --hook HOOK           Python callable that'll be used on every requests call
-    -n REQUESTS, --requests REQUESTS
+      -a AUTH, --auth AUTH  Basic authentication user:password
+      --header HEADER       Custom header. name:value
+      --pre-hook PRE_HOOK   Python module path (eg: mymodule.pre_hook) to a
+                            callable which will be executed before doing a request
+                            for example: pre_hook(method, url, options). It must
+                            return a tupple of parameters given in function
+                            definition
+      --post-hook POST_HOOK
+                            Python module path (eg: mymodule.post_hook) to a
+                            callable which will be executed after a request is
+                            done for example: eg. post_hook(response). It must
+                            return a given response parameter or raise an
+                            `boom._boom.RequestException` for failed request.
+      --json-output         Prints the results in JSON instead of the default
+                            format
+      -n REQUESTS, --requests REQUESTS
                             Number of requests
-    -d DURATION, --duration DURATION
+      -d DURATION, --duration DURATION
                             Duration in seconds
-    --json-output         Prints the results as a JSON object instead. Also
-                          silences the progress logging.
 
 
 


### PR DESCRIPTION
This adds a --validator option which is similar to --hooks but let's you validate the server response via a python callable. I used this to check load balancing and verify the content properly. Probably the next step would be to extend the calls so the validator function will take also headers as second argument, but that requires more changes.

Let me know what do you think about this.
