### PR TITLE
moving _boom.py to boom.py, adjusting other code as necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .tox/
 boom.egg-info/
 venv/
+dist/

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Boom! has more options::
                             callable which will be executed after a request is
                             done for example: eg. post_hook(response). It must
                             return a given response parameter or raise an
-                            `boom._boom.RequestException` for failed request.
+                            `boom.boom.RequestException` for failed request.
       --json-output         Prints the results in JSON instead of the default
                             format
       -n REQUESTS, --requests REQUESTS

--- a/boom/__init__.py
+++ b/boom/__init__.py
@@ -1,1 +1,2 @@
-__version__ = '0.9'
+# allows boom.main instead of boom.boom.main, etc
+from boom import *

--- a/boom/boom.py
+++ b/boom/boom.py
@@ -13,9 +13,11 @@ from gevent.pool import Pool
 from requests import RequestException
 from socket import gethostbyname, gaierror
 
-from boom import __version__, _patch     # NOQA
-from boom.util import resolve_name
-from boom.pgbar import AnimatedProgressBar
+import _patch # NOQA
+from util import resolve_name
+from pgbar import AnimatedProgressBar
+
+__version__ = '0.9'
 
 monkey.patch_all()
 
@@ -332,7 +334,7 @@ def main():
                               "a request is done for example: "
                               "eg. post_hook(response). "
                               "It must return a given response parameter or "
-                              "raise an `boom._boom.RequestException` for "
+                              "raise an `boom.boom.RequestException` for "
                               "failed request."),
                         type=str)
 

--- a/boom/tests/test_boom.py
+++ b/boom/tests/test_boom.py
@@ -9,9 +9,9 @@ from gevent.pywsgi import WSGIServer
 import requests
 import gevent
 
-from boom._boom import (run as runboom, main,
-                        resolve, RunResults, RequestException)
-from boom import _boom
+from boom.boom import (run as runboom, main,
+                       resolve, RunResults, RequestException)
+from boom import boom
 
 
 class App(object):
@@ -219,7 +219,7 @@ class TestBoom(unittest.TestCase):
         try:
             sys.stdout = StringIO.StringIO()
             sys.stderr = StringIO.StringIO()
-            _boom.print_json(results)
+            boom.print_json(results)
 
             sys.stdout.seek(0)
             output = sys.stdout.read()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-from boom import __version__
+from boom.boom import __version__
 import sys
 
 install_requires = ['gevent', 'requests', 'unittest2']
@@ -34,5 +34,5 @@ setup(name='boom',
       test_suite='unittest2.collector',
       entry_points="""
       [console_scripts]
-      boom = boom._boom:main
+      boom = boom.boom:main
       """)


### PR DESCRIPTION
Was thinking about doing this anyway, and then I saw [Issue #31](https://github.com/tarekziade/boom/issues/31).

``python setup.py test`` all tests pass most of the time. The dns resolve test fails occasionally, but I think that's a DNS issue on my machine, not an issue with the code, since it usually passes.

Not sure how relevant this is, but when I was trying to work on this, I was using ipython to test importing stuff and it was throwing a weird exception. It turns out that this is because ipython and gevent don't play well together, and had nothing to do with changes I was making.