### PR TITLE
Set 'stdev' to 0 if no results present

### DIFF
--- a/boom/_boom.py
+++ b/boom/_boom.py
@@ -78,7 +78,7 @@ def calc_stats(results):
     cum_time = sum(all_res)
 
     if cum_time == 0 or len(all_res) == 0:
-        rps = avg = min_ = max_ = amp = 0
+        rps = avg = min_ = max_ = amp = stdev = 0
     else:
         if results.total_time == 0:
             rps = 0


### PR DESCRIPTION
When parsing the result list to calculate the stats, if no results are
present set stdev to 0 like the other variables to avoid raising:
UnboundLocalError: local variable 'stdev' referenced before assignment
