### PR TITLE
Set minumum version of reqeusts required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from boom import __version__
 import sys
 
-install_requires = ['gevent', 'requests']
+install_requires = ['gevent', 'requests>=2.3.0']
 
 if sys.version_info < (2, 7):
     install_requires += ['argparse']


### PR DESCRIPTION
I had older version of `requests` installed (2.2.1) and I had the follwing error:

        from requests.packages.urllib3.util import parse_url
    ImportError: No module named 'requests.packages'

Upgrading to requests 2.3.0+ solved the problem.