### PR TITLE
Directly calling the load function.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,14 @@ Boom! has more options::
                             Duration in seconds
 
 
+Calling from Python code
+========================
+
+You can trigger load testing from Python code by importing the function `boom.boom.load` directly, as follows::
+
+    from boom.boom import load
+    result = load('http://example.com/', 1, 1, 0, 'GET', None, 'text/plain', None, quiet=True)
+
 
 Design
 ======


### PR DESCRIPTION
Hi, I found out that I could call the `load()` function directly, which helps me since I wanted to trigger multiple load testing tasks from a separate Python script. Doing this is much simpler than triggering child processes with the boom executable.

Just a suggestion that it might be nice to make this clear in the readme. Then someone can use this functionality without reading the source code.

I am happy to add more details to the documentation if this makes sense. I understand that this changes the interface of the software which needs to be maintained so I thought I would check first. Thanks!